### PR TITLE
Improve driving controls and add headless control simulations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ Top-down arcade-style racing game written in Python with pygame. Drive through t
 python main.py
 ```
 
-Controls use the arrow keys or WASD to steer and accelerate, with Down/S for braking or gentle reverse. Press `1`, `2`, or `3` in the menu to jump directly to a track, and `Esc`/`P` pauses the action in-race.
+Controls use the arrow keys or WASD to steer, `Up`/`W` to accelerate, `Down`/`S` to reverse, `Shift` for heavy braking, and `Space` for a quick handbrake flick. Press `1`, `2`, or `3` in the menu to jump directly to a track, and `Esc`/`P` pauses the action in-race.
+
+For quick iteration on the driving feel without launching pygame, run the deterministic control simulations:
+
+```bash
+python simulate_controls.py
+```
+
+The script exercises straight-line acceleration, sweeping turns, braking, and handbrake maneuvers while printing the resulting speeds and headings.
 
 Lap records are saved automatically in `records.json` next to the script.

--- a/simulate_controls.py
+++ b/simulate_controls.py
@@ -1,0 +1,90 @@
+"""Simple control simulation helpers for the vector racer car physics.
+
+The module runs a few deterministic scenarios so that the driving feel can be
+evaluated without launching the pygame window.  They are not meant to be
+exhaustive physics tests, but they provide quick feedback when tweaking the
+control parameters.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+import pygame
+
+from main import Car
+
+@dataclass
+class SimulationResult:
+    label: str
+    duration: float
+    final_speed: float
+    distance_travelled: float
+    heading_deg: float
+
+
+def _run(car: Car, inputs: Dict[str, float], duration: float, surface_mu: float = 1.0, dt: float = 1 / 120) -> None:
+    steps = int(duration / dt)
+    for _ in range(steps):
+        car.update(dt, inputs, surface_mu)
+
+
+def accelerate_from_rest(duration: float = 4.0) -> SimulationResult:
+    car = Car((0.0, 0.0), 0.0)
+    _run(car, {"throttle": 1.0, "steer": 0.0, "brake": 0.0}, duration)
+    speed = car.state.velocity.length() * 3.6
+    distance = car.state.position.length() / 20.0
+    heading = car.state.heading
+    return SimulationResult("Full throttle", duration, speed, distance, heading * 180.0 / 3.141592653589793)
+
+
+def high_speed_corner(duration: float = 5.0) -> SimulationResult:
+    car = Car((0.0, 0.0), 0.0)
+    _run(car, {"throttle": 1.0, "steer": 0.0, "brake": 0.0}, duration * 0.4)
+    _run(car, {"throttle": 0.75, "steer": 0.8, "brake": 0.0}, duration * 0.6)
+    speed = car.state.velocity.length() * 3.6
+    distance = car.state.position.length() / 20.0
+    heading = car.state.heading
+    return SimulationResult("Sweeping corner", duration, speed, distance, heading * 180.0 / 3.141592653589793)
+
+
+def braking_test(duration: float = 2.0) -> SimulationResult:
+    car = Car((0.0, 0.0), 0.0)
+    _run(car, {"throttle": 1.0, "steer": 0.0, "brake": 0.0}, 2.5)
+    _run(car, {"throttle": 0.0, "steer": 0.0, "brake": 1.0}, duration)
+    speed = car.state.velocity.length() * 3.6
+    distance = car.state.position.length() / 20.0
+    heading = car.state.heading
+    return SimulationResult("Threshold brake", duration, speed, distance, heading * 180.0 / 3.141592653589793)
+
+
+def handbrake_turn(duration: float = 3.0) -> SimulationResult:
+    car = Car((0.0, 0.0), 0.0)
+    _run(car, {"throttle": 1.0, "steer": 0.0, "brake": 0.0}, 1.5)
+    _run(car, {"throttle": 0.4, "steer": 1.0, "brake": 0.0, "handbrake": True}, duration)
+    speed = car.state.velocity.length() * 3.6
+    distance = car.state.position.length() / 20.0
+    heading = car.state.heading
+    return SimulationResult("Handbrake flick", duration, speed, distance, heading * 180.0 / 3.141592653589793)
+
+
+def main() -> None:
+    scenarios = [
+        accelerate_from_rest(),
+        high_speed_corner(),
+        braking_test(),
+        handbrake_turn(),
+    ]
+    for result in scenarios:
+        print(
+            f"{result.label:18s} | duration: {result.duration:4.1f}s | "
+            f"speed: {result.final_speed:6.1f} km/h | "
+            f"distance: {result.distance_travelled:5.2f} m | "
+            f"heading: {result.heading_deg:7.2f}°"
+        )
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- retune the car physics constants and steering logic for snappier acceleration, better braking, and a usable handbrake
- update the in-game help and README documentation to describe the revised throttle, brake, and handbrake bindings
- add a `simulate_controls.py` helper that runs deterministic control scenarios for tuning without launching pygame

## Testing
- python simulate_controls.py

------
https://chatgpt.com/codex/tasks/task_b_68dad9627ba8832d83f31fb14ce7f267